### PR TITLE
[tempfs] Fix tempfs_access offset shenanigans

### DIFF
--- a/src/fs/tempfs.c
+++ b/src/fs/tempfs.c
@@ -96,23 +96,19 @@ int tempfs_access(TempfsInode *file, char *buf, size_t len, size_t offset, bool 
     TempfsFileNode *this_fnode = file->first_file_node;
     size_t len_left = len;
     size_t off = 0;
-    size_t is_first = false;
     while (len_left > 0) {
-        size_t bytes_to_copy = (len_left > FILE_DATA_BLOCK_LEN) ? FILE_DATA_BLOCK_LEN : len_left;
         if (!this_fnode && !write) return -2; // EOF
         if (offset < FILE_DATA_BLOCK_LEN) {
+            size_t bytes_to_copy = (len_left > (FILE_DATA_BLOCK_LEN-offset)) ? (FILE_DATA_BLOCK_LEN-offset) : len_left;
             if (write) // accessing as write?
                 memcpy(this_fnode->data + offset, buf + off, bytes_to_copy);
             else // ...or accessing as read?
                 memcpy(buf + off, this_fnode->data + offset, bytes_to_copy);
             len_left -= bytes_to_copy;
             offset = 0;
-            is_first = false;
             off += bytes_to_copy;
         } else {
             offset -= FILE_DATA_BLOCK_LEN;
-            if (!is_first && offset <= FILE_DATA_BLOCK_LEN)
-                is_first = true;
         }
         if (write && !this_fnode->next && len_left > 0) {
             this_fnode->next = (TempfsFileNode*) (kmalloc(1) + kernel.hhdm);


### PR DESCRIPTION
Fix issue with offsets which caused the contents of the elf file to also be incorrect. Also removed unnecessary is_first boolean which wasn't actually used anywhere. Simplified logic and moved bytes_to_copy inside of the only scope that uses it (in the if body).

With this fix the init task is loaded correctly.

**Tempfs related NOTEs:**
- I would probably suggest splitting the "skipping all full block to offset" and "copying data" into two separate steps to simplify logic and remove unnecessary ifs. 
- I would assume access (read/write) should return the amount of bytes read/written which currently it returns 0
- The tempfs should handle not enough memory for expanding the file on write()

**Exec related NOTEs:**
- Add at least some sort of assertion for alignment as currently the code does not work if the virtual address is not page aligned and just assumes it everywhere (A real non-aligned thing will require changes in the code in places such as calculating the amount of pages necessary too)

**General Code related NOTEs:**
- Use less magic numbers (both in exec with the program header type and in returning errors in the file system)
- Handle allocation failure in all places (exec should handle both alloc_pages errors and errors with the memlist)
- Consider moving towards an Inode based design instead of the drive based one there is currently. This will dramatically simplify logic and helps with Unix compatibility